### PR TITLE
Compilation of fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set_target_properties (kapi PROPERTIES
 		      COMPILE_DEFINITIONS_DEBUG "JSON_DEBUG;JSON_SAFE;JSON_ISO_STRICT"
 		      DEBUG_POSTFIX "d")
 
-list (APPEND LIBS kapi)
+list (INSERT LIBS 0 kapi)
 
 #-------------------------------------------------------------------------------
 # Add library libjson

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ IF (APPLE)
 ENDIF (APPLE)
 
 #-------------------------------------------------------------------------------
-IF (COMMAND cmake_policy)
+IF (POLICY CMP0043)
 	cmake_policy(SET CMP0043 OLD)
 ENDIF()
 


### PR DESCRIPTION
This makes the code compile well on fresh Ubuntu 14.04 (at least). Some explatation:
1. `CMP0043` was only added in CMake 3.x, compiling with an older one results in an error. Either use what I did, or upgrade `cmake_minimum_required` macro.
2. You don't mention the libs before the units that reference them. This results in #2 (makes me wonder why it doesn't break in your setup). I changed `APPEND` to `INSERT` at the head of the list so `kapi` goes first and the libs it needs afterwards.
